### PR TITLE
Bugfix Issue #16 - Accessing disposed widget

### DIFF
--- a/lib/Data/book_storage.dart
+++ b/lib/Data/book_storage.dart
@@ -68,6 +68,10 @@ class BookStorage {
     }
   }
 
+  void removeOnBooksChangedCallback(ValueChanged<List<Book>> callback){
+    onBooksChanged.remove(callback);
+  }
+
   Future<String> get _localPath async {
     final directory = await getApplicationDocumentsDirectory();
 

--- a/lib/UI/layouts/pages/all_books_page.dart
+++ b/lib/UI/layouts/pages/all_books_page.dart
@@ -16,6 +16,12 @@ class AllBooksPageState extends State<AllBooksPage>{
     books = List<Book>();
   }
 
+  @override
+  void dispose() {
+    BookStorage.instance.removeOnBooksChangedCallback(setBooks);
+    super.dispose();
+  }
+
   void setBooks(List<Book> newBooks){
     setState(() {
       books = newBooks;

--- a/lib/UI/layouts/pages/all_books_page.dart
+++ b/lib/UI/layouts/pages/all_books_page.dart
@@ -13,7 +13,8 @@ class AllBooksPageState extends State<AllBooksPage>{
 
   AllBooksPageState(){
     BookStorage(onBooksChanged: setBooks);
-    books = List<Book>();
+    var storageBooks = BookStorage.instance.allBooks;
+    books = storageBooks != null ? storageBooks : List<Book>();
   }
 
   @override


### PR DESCRIPTION
Make sure listener for BookStorage's onBooksChanged event is removed when disposing the AllBooksPage. Make sure to properly load books from the BookStorage when creating the AllBooksPage widget.